### PR TITLE
Add LRT for fk

### DIFF
--- a/R/rate_estimation_two_conditions_helpers.R
+++ b/R/rate_estimation_two_conditions_helpers.R
@@ -74,7 +74,7 @@ mainExpectationMaximizationH0 <- function(fkInt, Xk1, Xk2, kmin, kmax, betaInt,
         }
         if (i > 1) {
             diff <- likelihoods[[i]] - likelihoods[[i - 1]]
-            if (diff <= tor) break
+            if (abs(diff) <= tor) break
         }
     }
     if (i == maxItr) flag <- "max_iteration"
@@ -86,12 +86,12 @@ mainExpectationMaximizationH0 <- function(fkInt, Xk1, Xk2, kmin, kmax, betaInt,
 }
 
 mainExpectationMaximizationFkH0 <- function(fkInt, Xk1, Xk2, kmin, kmax, betaInt1, betaInt2,
-                                            chiHat, chiHat1, chiHat2, scaleFactor, maxItr = 100, tor = 1e-3) {
+                                            chiHat, chiHat1, chiHat2, scaleFactor, maxItr = 200, tor = 1e-3) {
     likelihoods <- list(); flag <- "normal"
     for (i in seq_len(maxItr)) {
         if (i == 1) {
-            Yk1 <- getExpectation(fkInt, Xk1, betaInt)
-            Yk2 <- getExpectation(fkInt, Xk2, betaInt)
+            Yk1 <- getExpectation(fkInt, Xk1, betaInt1)
+            Yk2 <- getExpectation(fkInt, Xk2, betaInt2)
             fkLs <- getFk(Xk1 + Xk2 * scaleFactor, Yk1 + Yk2 * scaleFactor, fkInt, kmin, kmax)   
         }
         if (i != 1) {
@@ -106,8 +106,8 @@ mainExpectationMaximizationFkH0 <- function(fkInt, Xk1, Xk2, kmin, kmax, betaInt
         beta2 <- chiHat2/sum(Yk2)
 
         if (any(fk == 1)){
-            beta1 <- chi_hat1 / (Xk1[which(fk == 1)])
-            beta2 <- chi_hat2 / (Xk2[which(fk == 1)])
+            beta1 <- chiHat1 / (Xk1[which(fk == 1)])
+            beta2 <- chiHat2 / (Xk2[which(fk == 1)])
             flag <- 'single_site'
             fkLs$fkMean <- which(fk == 1)
             fkLs$fkSD <- 0
@@ -124,7 +124,7 @@ mainExpectationMaximizationFkH0 <- function(fkInt, Xk1, Xk2, kmin, kmax, betaInt
             )*scaleFactor
         if (i > 1) {
             diff <- likelihoods[[i]] - likelihoods[[i - 1]]
-            if (diff <= tor) break
+            if (abs(diff) <= tor) break
         }
     }
     if (i == maxItr) flag <- "max_iteration"

--- a/R/transcription_rates_lrt-class.R
+++ b/R/transcription_rates_lrt-class.R
@@ -225,10 +225,11 @@ runEMH1BetaLRT <- function(params, h0Results, kmin, kmax, maxItr, tor, scaleFact
 
 runEMH1FkLRT <- function(params, h0Results, kmin, kmax, maxItr, tor, scaleFactor) {
     tStats <- params$rc1Likelihood + params$rc2Likelihood * scaleFactor - h0Results$h0Likelihood
+    h0Beta1 <- map_dbl(h0Results$emRes, "beta1");  h0Beta2 <- map_dbl(h0Results$emRes, "beta2")
     idx <- tStats < 0; h0Fk <- map(h0Results$emRes, "fk")
     
     emHc <- pmap(
-        list(h0Fk[idx], params$Xk1[idx], params$betaInt1[idx], params$chiHat1[idx]),
+        list(h0Fk[idx], params$Xk1[idx], h0Beta1[idx], params$chiHat1[idx]),
         function(x, y, z, k) {
             tryCatch(
                 pauseEscapeEM(
@@ -245,7 +246,7 @@ runEMH1FkLRT <- function(params, h0Results, kmin, kmax, maxItr, tor, scaleFactor
         }
     )
     emHt <- pmap(
-        list(h0Fk[idx], params$Xk2[idx], params$betaInt2[idx], params$chiHat2[idx]),
+        list(h0Fk[idx], params$Xk2[idx], h0Beta2[idx], params$chiHat2[idx]),
         function(x, y, z, k) {
             tryCatch(
                 pauseEscapeEM(

--- a/R/transcription_rates_lrt-class.R
+++ b/R/transcription_rates_lrt-class.R
@@ -102,7 +102,7 @@ computeFkLRTParams <- function(rc1, rc2, scaleFactor, kmin, kmax, gbLength) {
 
     list(
         fkInt = fkInt, s1 = s1, s2 = s2, t1H1 = t1H1, t2H1 = t2H1,
-        Xk1 = Xk1, Xk2 = Xk2, M = M, chiHat = chiHat, betaInt1 = betaInt1, betaInt2 = betaInt2
+        Xk1 = Xk1, Xk2 = Xk2, M = M, chiHat = chiHat, betaInt1 = betaInt1, betaInt2 = betaInt2,
         chiHat1 = chiHat1, chiHat2 = chiHat2,
         rc1Likelihood = rc1Likelihood, rc2Likelihood = rc2Likelihood
     )
@@ -225,7 +225,7 @@ runEMH1BetaLRT <- function(params, h0Results, kmin, kmax, maxItr, tor, scaleFact
 
 runEMH1FkLRT <- function(params, h0Results, kmin, kmax, maxItr, tor, scaleFactor) {
     tStats <- params$rc1Likelihood + params$rc2Likelihood * scaleFactor - h0Results$h0Likelihood
-    idx <- tStats < 0; h0Fk <- map_dbl(h0Results$emRes, "fk")
+    idx <- tStats < 0; h0Fk <- map(h0Results$emRes, "fk")
     
     emHc <- pmap(
         list(h0Fk[idx], params$Xk1[idx], params$betaInt1[idx], params$chiHat1[idx]),


### PR DESCRIPTION
I added a likelihood ratio test for fk. The overall implementation closely follows the LRT framework previously used for beta, with only minor modifications to accommodate the parameterization of fk.
